### PR TITLE
Query Router

### DIFF
--- a/router/query_router.py
+++ b/router/query_router.py
@@ -1,0 +1,17 @@
+from typing import List, Dict
+import numpy as np
+
+
+def rout_query(centroids: Dict[str, List], query_embedding: List) -> str:
+    centroids = list(centroids.items())
+    centroids_np = np.array([value for key, value in centroids])
+    query_np = np.array(query_embedding)
+
+    norm_query = np.linalg.norm(query_np)
+    norm_centroids = np.linalg.norm(centroids_np, axis=1)
+
+    cosine_similarities = np.dot(centroids_np, query_np) / (norm_centroids * norm_query)
+    max_index = np.argmax(cosine_similarities)
+
+    collection = centroids[max_index][0]
+    return collection

--- a/router/router-dev.ipynb
+++ b/router/router-dev.ipynb
@@ -1,0 +1,194 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 39,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "import os\n",
+    "from pathlib import Path\n",
+    "from typing import Dict, List\n",
+    "\n",
+    "import numpy as np\n",
+    "from loguru import logger\n",
+    "from tqdm.auto import tqdm"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Calculate centroids for all collections"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "embeddings_dir = Path(\"../database/embeddings\")\n",
+    "embeddings_paths = [\n",
+    "    path for path in list(embeddings_dir.iterdir()) if path.suffix == \".jsonl\"\n",
+    "]\n",
+    "if not embeddings_dir.exists():\n",
+    "    logger.error(f\"Embeddings dir not found: {embeddings_dir}.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def load_embeddings(path: Path) -> List:\n",
+    "    if not path.exists():\n",
+    "        logger.error(f\"File does not exist: {path}.\")\n",
+    "\n",
+    "    with open(path, \"r\", encoding=\"utf-8\") as file:\n",
+    "        embeddings = []\n",
+    "        for line in file:\n",
+    "            embeddings.append(json.loads(line)[1][\"data\"][0][\"embedding\"])\n",
+    "\n",
+    "    return embeddings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 34,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "7d0747d4d8964a32aefa93fcef21da77",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Calculating centroids:   0%|          | 0/5 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "collection_centroids = {}\n",
+    "for file_path in tqdm(\n",
+    "    embeddings_paths, desc=\"Calculating centroids\", total=len(embeddings_paths)\n",
+    "):\n",
+    "    embeddings = load_embeddings(file_path)\n",
+    "    centroid = np.array(embeddings).mean(axis=0)\n",
+    "    collection_centroids[file_path.stem] = centroid.tolist()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "centroid_path = Path(\"./collection_centroids.json\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Save centroids"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 38,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with open(centroid_path, \"w\", encoding=\"utf-8\") as file:\n",
+    "    file.write(json.dumps(collection_centroids, indent=4))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Query router dev"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 46,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def rout_query(centroids: Dict, query_embedding: List) -> str:\n",
+    "    centroids = list(centroids.items())\n",
+    "    centroids_np = np.array([value for key, value in centroids])\n",
+    "    query_np = np.array(query_embedding)\n",
+    "\n",
+    "    norm_query = np.linalg.norm(query_np)\n",
+    "    norm_centroids = np.linalg.norm(centroids_np, axis=1)\n",
+    "\n",
+    "    cosine_similarities = np.dot(centroids_np, query_np) / (norm_centroids * norm_query)\n",
+    "    max_index = np.argmax(cosine_similarities)\n",
+    "\n",
+    "    collection = centroids[max_index][0]\n",
+    "    return collection"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 47,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'porodicni_zakon'"
+      ]
+     },
+     "execution_count": 47,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "rout_query(\n",
+    "    centroids=collection_centroids,\n",
+    "    query_embedding=collection_centroids[\"porodicni_zakon\"],\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
## Query Router

Integrate Query Routing using collection centroids. We first calculate centroids for every collection. Afterwards, we create lookup: collection_name -> collection_centroid
- Add dev notebook
- Add script for query routing using centroids